### PR TITLE
Fix python version exception

### DIFF
--- a/python_appimage/commands/build/app.py
+++ b/python_appimage/commands/build/app.py
@@ -53,6 +53,7 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
             if v > version:
                 release, version = entry, v
         elif v == python_version:
+            version = python_version
             release = entry
             break
     if release is None:


### PR DESCRIPTION
This PR fix the error when use `-p` argument:
```
$ python -m python_appimage build app -p 3.7 applications/xonsh
Traceback (most recent call last):
  File "/home/pc/miniconda3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/pc/miniconda3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/pc/xxh/pa/python-appimage/python_appimage/__main__.py", line 92, in <module>
    main()
  File "/home/pc/xxh/pa/python-appimage/python_appimage/__main__.py", line 88, in main
    command.execute(*command._unpack_args(args))
  File "/home/pc/xxh/pa/python-appimage/python_appimage/commands/build/app.py", line 88, in execute
    raise ValueError('Could not find base image for tag ' + target_tag)
ValueError: Could not find base image for tag cp00-cp00m-manylinux1_x86_64
```