### PR TITLE
Fix: PyPi in-tree-build error

### DIFF
--- a/python_appimage/commands/build/app.py
+++ b/python_appimage/commands/build/app.py
@@ -229,7 +229,7 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
         # Bundle the requirements
         if requirements_list:
             deprecation = 'DEPRECATION: Python 2.7 reached the end of its life'
-            system(('./AppDir/AppRun', '-m', 'pip', 'install', '-U',
+            system(('./AppDir/AppRun', '-m', 'pip', 'install', '-U', '--use-feature=in-tree-build',
                    '--no-warn-script-location', 'pip'), exclude=deprecation)
             for requirement in requirements_list:
                 if requirement.startswith('git+'):
@@ -237,7 +237,7 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
                     log('BUNDLE', name + ' from ' + url[4:])
                 else:
                     log('BUNDLE', requirement)
-                system(('./AppDir/AppRun', '-m', 'pip', 'install', '-U',
+                system(('./AppDir/AppRun', '-m', 'pip', 'install', '-U', '--use-feature=in-tree-build',
                        '--no-warn-script-location', requirement),
                        exclude=(deprecation, '  Running command git clone -q'))
 


### PR DESCRIPTION
Closes #31 

Fixed the error:

> DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
