### PR TITLE
Fix: Running pip as root

### DIFF
--- a/python_appimage/commands/build/app.py
+++ b/python_appimage/commands/build/app.py
@@ -233,7 +233,8 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
 
             deprecation = (
                 'DEPRECATION: Python 2.7 reached the end of its life',
-                'DEPRECATION: Python 3.5 reached the end of its life'
+                'DEPRECATION: Python 3.5 reached the end of its life',
+                'WARNING: Running pip as root'
             )
 
             system(('./AppDir/AppRun', '-m', 'pip', 'install', '-U', in_tree_build,


### PR DESCRIPTION
Hi @niess !
This fixed the error:
```python
[2021-05-03 14:51:42,328] EXTRACT  python3.9.4-cp39-cp39-manylinux1_x86_64.AppImage
[2021-05-03 14:51:43,660] BUNDLE   xonsh.desktop
[2021-05-03 14:51:43,661] BUNDLE   xonsh.appdata.xml
Traceback (most recent call last):
  ...
  File "/opt/conda/lib/python3.8/site-packages/python_appimage/commands/build/app.py", line 239, in execute
    system(('./AppDir/AppRun', '-m', 'pip', 'install', '-U', in_tree_build,
  File "/opt/conda/lib/python3.8/site-packages/python_appimage/utils/system.py", line 42, in system
    raise RuntimeError(err)
RuntimeError: WARNING: Running pip as root will break packages and permissions. You should install packages reliably by using venv: https://pip.pypa.io/warnings/venv
```

It looks like build command is pretty fragile. May be the best approach is to ignore all warnings in the future?
