### PR TITLE
added ssh-mitm application

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -39,9 +39,8 @@ jobs:
         test -e xonsh-x86_64.AppImage
         ./xonsh-x86_64.AppImage -c 'import xonsh'
 
-
     - name: Test ssh-mitm
       run: |
         python -m python_appimage build app applications/ssh-mitm
         test -e ssh-mitm-x86_64.AppImage
-        ./ssh-mitm-x86_64.AppImage -c 'import ssh_proxy_server'
+        ./ssh-mitm-x86_64.AppImage --help'

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['2.7', '3.5']
+        version: ['2.7', '3.5', '3.6']
 
     steps:
     - uses: actions/checkout@v2
@@ -40,7 +40,8 @@ jobs:
         ./xonsh-x86_64.AppImage -c 'import xonsh'
 
     - name: Test ssh-mitm
+      if: ${{ matrix.version == '3.6' }}
       run: |
         python -m python_appimage build app applications/ssh-mitm
         test -e ssh-mitm-x86_64.AppImage
-        ./ssh-mitm-x86_64.AppImage --help'
+        ./ssh-mitm-x86_64.AppImage --help

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -38,3 +38,9 @@ jobs:
         python -m python_appimage build app applications/xonsh
         test -e xonsh-x86_64.AppImage
         ./xonsh-x86_64.AppImage -c 'import xonsh'
+
+    - name: Test ssh-mitm
+      run: |
+        python -m python_appimage build app applications/ssh-mitm
+        test -e ssh-mitm-x86_64.AppImage
+        ./ssh-mitm-x86_64.AppImage -c 'import ssh_proxy_server'

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -39,6 +39,7 @@ jobs:
         test -e xonsh-x86_64.AppImage
         ./xonsh-x86_64.AppImage -c 'import xonsh'
 
+
     - name: Test ssh-mitm
       run: |
         python -m python_appimage build app applications/ssh-mitm

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Running Python from these [AppImages][APPIMAGE] is as simple as downloading a
 single file and changing its mode to executable, e.g.  as:
 
 ```sh
-wget https://github.com/niess/python-appimage/releases/download/\
-python3.9/python3.9.4-cp39-cp39-manylinux1_x86_64.AppImage
-chmod +x python3.9.4-cp39-cp39-manylinux1_x86_64.AppImage
+wget https://github.com/niess/python-appimage/releases/download\
+/python3.10/python3.10.0-cp310-cp310-manylinux2010_x86_64.AppImage
+chmod +x python3.10.0-cp310-cp310-manylinux2010_x86_64.AppImage
 
-./python3.9.4-cp39-cp39-manylinux1_x86_64.AppImage
+./python3.10.0-cp310-cp310-manylinux2010_x86_64.AppImage
 ```
 
-This should start a Python 3.8 interactive session on _almost_ any Linux
+This should start a Python 3.10 interactive session on _almost_ any Linux
 provided that `fuse` is available. Note that on WSL1 since `fuse` is not
 supported you will need to extract the AppImage as explained hereafter.
 
@@ -30,11 +30,11 @@ its standard library.  However, if you plan to install extra packages we
 recommend extracting the AppImage, e.g. as:
 
 ```sh
-./python3.9.4-cp39-cp39-manylinux1_x86_64.AppImage --appimage-extract
-mv squashfs-root python3.9
-rm -f python3.9.4-cp39-cp39-manylinux1_x86_64.AppImage
+./python3.10.0-cp310-cp310-manylinux2010_x86_64.AppImage --appimage-extract
+mv squashfs-root python3.10
+rm -f python3.10.0-cp310-cp310-manylinux2010_x86_64.AppImage
 
-export PATH="$(pwd)/python3.9/usr/bin:$PATH"
+export PATH="$(pwd)/python3.10/usr/bin:$PATH"
 ```
 
 Then, extra packages can be installed to the extracted AppDir using `pip`. For

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ packages. Then, simply rebuild the AppImage using your favourite tool, e.g.
 * [grand/python](https://github.com/grand-mother/python) - Contained, portable
   and modern python for [GRAND][GRAND] running from an AppImage
 * [xxh](https://github.com/xxh/xxh) - Bring your favorite shell wherever you go
-  through the ssh 
-* [xonsh](https://github.com/xonsh/xonsh) - Python-powered, cross-platform, Unix-gazing 
+  through the ssh
+* [xonsh](https://github.com/xonsh/xonsh) - Python-powered, cross-platform, Unix-gazing
   shell language and command prompt
 * [rever](https://github.com/regro/rever) - Cross-platform software release tool.
+* [ssh-mitm](https://github.com/ssh-mitm/ssh-mitm) - ssh mitm server for security audits
 
 
 [APPIMAGE]: https://appimage.org

--- a/applications/ssh-mitm/entrypoint.sh
+++ b/applications/ssh-mitm/entrypoint.sh
@@ -1,0 +1,2 @@
+#! /bin/bash -i
+{{ python-executable }} -u "${APPDIR}/opt/python{{ python-version }}/bin/ssh-mitm" "$@"

--- a/applications/ssh-mitm/requirements.txt
+++ b/applications/ssh-mitm/requirements.txt
@@ -1,0 +1,1 @@
+ssh-mitm

--- a/applications/ssh-mitm/ssh-mitm.appdata.xml
+++ b/applications/ssh-mitm/ssh-mitm.appdata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>ssh-mitm</id>
+    <metadata_license>MIT</metadata_license>
+    <project_license>Python-2.0</project_license>
+    <name>SSH-MITM</name>
+    <summary>SSH-MITM on Python {{ python-fullversion }}</summary>
+    <description>
+        <p>  Python {{ python-fullversion }} + SSH-MITM bundled in an AppImage.
+        </p>
+    </description>
+    <launchable type="desktop-id">ssh-mitm.desktop</launchable>
+    <url type="homepage">https://www.ssh.mitm.at</url>
+    <provides>
+        <binary>python{{ python-version }}</binary>
+    </provides>
+</component>

--- a/applications/ssh-mitm/ssh-mitm.desktop
+++ b/applications/ssh-mitm/ssh-mitm.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=ssh-mitm
+Exec=ssh-mitm
+Comment=SSH-MITM on Python {{ python-fullversion }}
+Icon=python
+Categories=System;
+Terminal=true


### PR DESCRIPTION
I have updated the python versions in the readme and fixed the download link.

Also a project template for [ssh-mitm](https://github.com/ssh-mitm/ssh-mitm/) was added as an additional example how to deploy a python application.