### PR TITLE
Option to copy requirements locally instead of using pip

### DIFF
--- a/python_appimage/commands/build/app.py
+++ b/python_appimage/commands/build/app.py
@@ -264,17 +264,18 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
                     _, name = requirement.split('+')
                     module = importlib.util.find_spec(name).origin
                     if module.endswith('.so'):
+                        log('BUNDLE', f'{name} (local)')
                         destination = f'AppDir/opt/python{python_version}/lib/python{python_version}/site-packages/'
                         copy_file(module, destination)
                     else:
+                        log('BUNDLE', f'{name} (local)')
                         destination = f'AppDir/opt/python{python_version}/lib/python{python_version}/site-packages/{name}/'
                         source = os.path.dirname(module)
                         copy_tree(source, destination)
-                    log('BUNDLE', f'{name} (local)')
                     continue
                 else:
                     log('BUNDLE', requirement)
-                system(('./AppDir/AppRun', '-m', 'pip', 'install', '-U', in_tree_build,
+                system(('./AppDir/AppRun', '-I', '-m', 'pip', 'install', '-U', in_tree_build,
                        '--no-warn-script-location', requirement),
                        exclude=(deprecation, '  Running command git clone'))
 

--- a/python_appimage/utils/compat.py
+++ b/python_appimage/utils/compat.py
@@ -1,4 +1,7 @@
-__all__ = ['decode']
+import sys
+
+
+__all__ = ['decode', 'find_spec', 'isolation_flag']
 
 
 def decode(s):
@@ -8,3 +11,21 @@ def decode(s):
         return s.decode()
     except Exception:
         return str(s)
+
+
+if sys.version_info[0] == 2:
+    from collections import namedtuple
+    import imp
+
+    ModuleSpec = namedtuple('ModuleSpec', ('name', 'origin'))
+
+    def find_spec(name):
+        return ModuleSpec(name, imp.find_module(name)[1])
+
+    isolation_flag = '-sE'
+
+else:
+    import importlib
+    find_spec = importlib.util.find_spec
+
+    isolation_flag = '-I'


### PR DESCRIPTION
- Adds the option to copy a local module from the host instead of pulling one from pip.
- Prepend `local+` to mark module for local copy (analogous to existing `git+` syntax).
- Copies either the the module directory (from `modulename.__file__`) or an `*.so` file for cpython wrapped modules.
- Doesn't check for dependencies.
- Runs pip install in an isolated environment (`-I`) to avoid skipping installing modules in host's environment.

Usage in requirements.txt:
```
# Install using pip
numpy
# Install via local copy from host
local+serial
```