### PR TITLE
Importing importlib fails with 'AttributeError' for python >= 3.8

### DIFF
--- a/python_appimage/utils/compat.py
+++ b/python_appimage/utils/compat.py
@@ -24,4 +24,8 @@ if sys.version_info[0] == 2:
 
 else:
     import importlib
-    find_spec = importlib.util.find_spec
+    try:
+        find_spec = importlib.util.find_spec
+    except AttributeError:
+        import importlib.util
+        find_spec = importlib.util.find_spec


### PR DESCRIPTION
Using importlib.util, if importlib fails.