### PR TITLE
Added support for git dependencies with custom branch name.

### DIFF
--- a/python_appimage/commands/build/app.py
+++ b/python_appimage/commands/build/app.py
@@ -253,6 +253,12 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
                 'WARNING: Running pip as'
             )
 
+            git_warnings = (
+                re.compile(r'\s+Running command git (clone|checkout) '),
+                re.compile(r"\s+Branch '.*' set up to track remote"),
+                re.compile(r"\s+Switched to a new branch '.*'"),
+            )
+
             isolation_flag = '-sE' if python_version[0] == '2' else '-I'
             system(('./AppDir/AppRun', isolation_flag, '-m', 'pip', 'install', '-U', in_tree_build,
                    '--no-warn-script-location', 'pip'), exclude=deprecation)
@@ -279,7 +285,7 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
                     log('BUNDLE', requirement)
                 system(('./AppDir/AppRun', isolation_flag, '-m', 'pip', 'install', '-U', in_tree_build,
                        '--no-warn-script-location', requirement),
-                       exclude=(deprecation, '  Running command git clone'))
+                       exclude=(deprecation + git_warnings))
 
 
         # Bundle the entry point

--- a/python_appimage/utils/system.py
+++ b/python_appimage/utils/system.py
@@ -41,9 +41,16 @@ def system(args, exclude=None, stdin=None):
     if err:
         err = decode(err)
         stripped = [line for line in err.split(os.linesep) if line]
+
+        def matches_pattern(line, pattern):
+            if isinstance(pattern, re.Pattern):
+                return bool(pattern.match(line))
+            return line.startswith(pattern)
+
         for pattern in exclude:
             stripped = [line for line in stripped
-                        if not line.startswith(pattern)]
+                        if not matches_pattern(line, pattern)]
+
         if stripped:
             # Tolerate single line warning(s)
             for line in stripped:


### PR DESCRIPTION
It seems that `git` will print additional logs to `stderr` when custom branch name is used in dependency:

```
git+ssh://git@github.com/[group-name]/[repo-name].git@[branch-name]
```

This PR aims at supporting such dependencies.