### PR TITLE
Added support for bundling in auxilliary files

### DIFF
--- a/python_appimage/__main__.py
+++ b/python_appimage/__main__.py
@@ -7,6 +7,11 @@ import sys
 __all__ = ['main']
 
 
+def directory(path):
+    if not os.path.isdir(path):
+        raise argparse.ArgumentTypeError("Not a directory: {}".format(path))
+    return os.path.abspath(path)
+
 def main():
     '''Entry point for the CLI
     '''
@@ -73,6 +78,8 @@ def main():
                                   help='force pip in-tree-build',
                                   action='store_true',
                                   default=False)
+    build_app_parser.add_argument('-x', '--extra-files', type=directory,
+        help='path to directory containing extra files to be baked in')
 
     list_parser = subparsers.add_parser('list',
         description='List Python versions installed in a manylinux image')

--- a/python_appimage/commands/build/app.py
+++ b/python_appimage/commands/build/app.py
@@ -287,6 +287,12 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
                        '--no-warn-script-location', requirement),
                        exclude=(deprecation + git_warnings))
 
+        # Bundle auxilliary application files
+        aux_files_path = glob.glob(appdir + '/files')
+        if aux_files_path:
+            aux_files_path = aux_files_path[0]
+            log('BUNDLE', os.path.basename(aux_files_path))
+            copy_tree(aux_files_path, 'AppDir/')
 
         # Bundle the entry point
         entrypoint_path = glob.glob(appdir + '/entrypoint.*')

--- a/python_appimage/commands/build/app.py
+++ b/python_appimage/commands/build/app.py
@@ -26,14 +26,14 @@ def _unpack_args(args):
     '''Unpack command line arguments
     '''
     return args.appdir, args.name, args.python_version, args.linux_tag,        \
-           args.python_tag, args.base_image, args.in_tree_build
+           args.python_tag, args.base_image, args.in_tree_build, args.extra_files
 
 
 _tag_pattern = re.compile('python([^-]+)[-]([^.]+)[.]AppImage')
 _linux_pattern = re.compile('manylinux([0-9]+)_' + platform.machine())
 
 def execute(appdir, name=None, python_version=None, linux_tag=None,
-            python_tag=None, base_image=None, in_tree_build=False):
+            python_tag=None, base_image=None, in_tree_build=False, extra_files=None):
     '''Build a Python application using a base AppImage
     '''
 
@@ -288,11 +288,9 @@ def execute(appdir, name=None, python_version=None, linux_tag=None,
                        exclude=(deprecation + git_warnings))
 
         # Bundle auxilliary application files
-        aux_files_path = glob.glob(appdir + '/files')
-        if aux_files_path:
-            aux_files_path = aux_files_path[0]
-            log('BUNDLE', os.path.basename(aux_files_path))
-            copy_tree(aux_files_path, 'AppDir/')
+        if extra_files is not None:
+            log('BUNDLE', os.path.basename(extra_files))
+            copy_tree(extra_files, 'AppDir/')
 
         # Bundle the entry point
         entrypoint_path = glob.glob(appdir + '/entrypoint.*')


### PR DESCRIPTION
Hi,
My intentions with this PR are to spur discussion whether it would make sense. Then, if we come to agreement, I can move it forward.

In a nutshell, what we need in order to use `python-appimage` is a way to bundle auxiliary files that can be then accessed by script invoked by entrypoint. These files are Docker images, thus quite big, and cannot be included in any other way.

The change from this PR is enough to make it work - just create `files/` in the App dir and it will then be available to the script. However, I'm not sure if such implementation is good enough:
* I'm not sure about naming: is `files/` okay?
* I'm not sure if this shouldn't be configurable - e.g. some conf file specifies where auxiliary files are stores
* does our reasoning make sense at all and is it okay to put such functionality :wink: 

Please let me know what do you think about it. Then, I guess it would be necessary to include some info in the docs etc. I can take care of this.