### PR TITLE
backup original sys.executable path

### DIFF
--- a/python_appimage/data/_initappimage.py
+++ b/python_appimage/data/_initappimage.py
@@ -12,7 +12,9 @@ def _initappimage():
 
     if command and ("APPDIR" in env):
         command = os.path.abspath(command)
+        sys.executable_original = sys.executable
         sys.executable = command
+        sys._base_executable_original = sys._base_executable
         sys._base_executable = command
 
 _initappimage()


### PR DESCRIPTION
When you change the sys.executable path to the AppImage, other modules cannot start the internal interpreter because it launches the AppImage again instead of the included Python binary.

By adding the mentioned changes to the init_appimage module, it will be possible to access the original/unpatched sys.executable value.

This pull request stores the original sys.executable as executable_original, which allows addressing the included Python binary instead of the AppImage. Although this is not a Python default, it enables module authors to create custom entry point scripts that need to execute the Python binary.

**Note:**
I'm working on an AppImage entry point script to enhance Python AppImage applications: https://github.com/ssh-mitm/appimage

This entry point script makes it possible to start the application by defining an environment variable in the AppRun script, but other methods can also be supported:

```
export PYTHON_ENTRY_POINT="ssh-mitm"
"$APPDIR/opt/python3.11/bin/python3.11" -m appimage "$@"
```

The appimage module allows interaction with the AppImage using additional arguments:

```
options:
  --python-help         Show this help message and exit.
  --python-interpreter  Start the Python interpreter.
  --python-venv PYTHON_VENV_DIR
                        Create a virtual environment pointing to the AppImage.
  --python-entry-point PYTHON_ENTRY_POINT
                        Start a Python entry point from console scripts (e.g., ssh-mitm).
```

Additional Note: The appimage module only provides an entry point, which can be used inside an AppImage to help initialize Python applications. It can be used in different AppImage setups like yours (python-appimage), appimage-builder, or custom setups.

Moreover, the appimage module aims to develop a unified interface, independent of the tool used to create the AppImage. This will allow different implementations to work together seamlessly, making Python AppImages more compatible and easier to use. 